### PR TITLE
make compress_worst_size() static

### DIFF
--- a/lzokay.hpp
+++ b/lzokay.hpp
@@ -72,7 +72,7 @@ inline EResult compress(const uint8_t* src, std::size_t src_size,
   return compress(src, src_size, dst, dst_size, out_size, dict);
 }
 
-constexpr std::size_t compress_worst_size(std::size_t s) {
+static constexpr std::size_t compress_worst_size(std::size_t s) {
   return s + s / 16 + 64 + 3;
 }
 


### PR DESCRIPTION
The test sample failed to link with some toolchain because the function existed twice in the linked binary.