### PR TITLE
Fix building on gcc>=12 and Clang >=13 by including <iterator> explicitly.

### DIFF
--- a/lzokay.cpp
+++ b/lzokay.cpp
@@ -1,6 +1,7 @@
 #include "lzokay.hpp"
 #include <cstring>
 #include <algorithm>
+#include <iterator>
 
 /*
  * Based on documentation from the Linux sources: Documentation/lzo.txt


### PR DESCRIPTION
- Include `<iterator>` explicitly for building on gcc12, clang13 and higher.